### PR TITLE
Enhance profile page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,2 +1,3 @@
-theme: jekyll-theme-minimal
-title: Miyuru's homepage
+theme: jekyll-theme-modernist
+title: Miyuru Thathsara
+description: PhD student at NTU Singapore researching FPGA-based hardware acceleration

--- a/index.md
+++ b/index.md
@@ -1,13 +1,57 @@
 ---
-title: My page
+title: Miyuru Thathsara
 layout: default
 ---
 
-# {{ Miyuru's Webpage! }}
+![Miyuru Thathsara](me.jpeg)
 
+## Profile
+I’m a friendly person who enjoys working in flexible environments with a mindset for problem solving. I love approaching challenges from different perspectives and have a keen interest in algorithm development. With a solid background in mathematics, embedded systems and reconfigurable hardware design, I thrive as an enthusiastic team player.
 
-## ![Image](\me.jpeg)
+## Research Interests
+- Embedded systems and FPGA-based acceleration
+- Reconfigurable hardware design for machine learning and SLAM
+- Hardware/software co-design and high-level synthesis
+- Algorithm development for efficient computing
 
-Miyuru is one of the best people and everyone's favourite.
+## Education
+- **PhD Student**, School of Computer Science and Engineering, Nanyang Technological University, Singapore *(2022 – present)*
+- **BSc (Hons) in Electronics and Telecommunication Engineering**, University of Moratuwa, Sri Lanka *(2016 – 2021, GPA 3.74/4.2, First Class)*  
+  Digital IC Design (A+), Advanced Digital System (A+)
+- **Certificate Level in Management**, Achievers Lanka Business School *(2015 – 2016)*
+- **High School**, Nalanda College, Colombo *(2002 – 2015)*  
+  Z-score 2.5017 (Island Rank 119) with A grades in Combined Mathematics, Chemistry, Physics; 9 A’s in the Ordinary Level exam
 
-Connect to me via my [LinkedIn](https://lk.linkedin.com/in/miyuru-thathsara-07596518b?original_referer=https%3A%2F%2Fwww.google.com%2F).
+## Experience
+- **Project Officer (Research)**, HESL, SCSE, NTU Singapore *(Jul 2022 – present)*  
+  Implementation of a SLAM algorithm in FPGA
+- **Engineer, Accelerated Systems**, HWAC Team, LSEG Technologies Sri Lanka *(May 2021 – Aug 2022)*  
+  Custom AXI DMA engine development and partial reconfiguration support
+- **Research Assistant**, HESL, SCSE, NTU Singapore *(Jul – Dec 2019)*  
+  Streaming hardware architectures for deep learning and self‑organization map classifier
+- **Drone Research Project Assistant**, UAV Lab, University of Moratuwa *(Jan 2018)*  
+  Built a PWM resolver with Arduino Mega for a multi‑rotor platform
+
+## Publications and Patent
+- **Hardware Accelerator for Feature Matching with Binary Search Tree** *(2024, patent pending)*  
+  *Abstract:* Presents an FPGA-based accelerator that uses a binary search tree to speed up feature matching in computer vision applications. [Search](https://www.google.com/search?q=Hardware+Accelerator+for+Feature+Matching+with+Binary+Search+Tree)
+- **Dynamically Growing Neural Network Architecture for Lifelong Deep Learning on the Edge** *(FPL&nbsp;2020)*  
+  *Abstract:* Describes a neural network architecture capable of expanding dynamically to accommodate new tasks while running efficiently on edge devices. [Search](https://www.google.com/search?q=Dynamically+Growing+Neural+Network+Architecture+for+Lifelong+Deep+Learning+on+the+Edge)
+- **Feasibility Study of a Novel Cross Assembled Multi‑quadrotor Unmanned Aerial Vehicle** *(ICIAfS&nbsp;2018)*  
+  *Abstract:* Explores a cross‑assembled multi‑quadrotor design for improved payload and maneuverability. [Search](https://www.google.com/search?q=Feasibility+Study+of+a+Novel+Cross+Assembled+Multi-quadrotor+Unmanned+Aerial+Vehicle)
+
+## Achievements
+- Dean’s List at University of Moratuwa (Semesters&nbsp;1, 2, 3, 6 and 8)
+- Represented Nalanda College in science society quiz competitions (2014–2015)  
+  First runners up at Devi Balika College quiz and finalist in Royal College quiz
+- Distinction pass at the 2014 Olympiad Mathematics Competition
+- Chess team captain (2005–2010) with national‑level placements
+
+## Activities & Hobbies
+Enjoy robotics projects, hiking, chess and sharing knowledge with the community.
+
+## Contact
+- Email: [mthathsara@outlook.com](mailto:mthathsara@outlook.com)
+- LinkedIn: [Miyuru Thathsara](https://lk.linkedin.com/in/miyuru-thathsara-07596518b)
+- Twitter: [@ThathsaraMiyuru](https://twitter.com/ThathsaraMiyuru)
+- GitHub: [MiyuruThathsara](https://github.com/MiyuruThathsara)


### PR DESCRIPTION
## Summary
- switch to the modernist theme for a cleaner layout
- rewrite the homepage with full profile, education, experience, publications and contact details

## Testing
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687150a86eb8832b954f7b771c0278b7